### PR TITLE
Updated/Added req dev dependencies to build forge on current hexal version

### DIFF
--- a/.architectury-transformer/debug.log
+++ b/.architectury-transformer/debug.log
@@ -1,1 +1,1 @@
-[Architectury Transformer DEBUG] Closed File Systems for /home/walksanator/git/mods/HexTweaks/common/build/libs/hextweaks-2.2.1.jar
+[Architectury Transformer DEBUG] Closed File Systems for D:\git\HexTweaks\common\build\libs\hextweaks-3.2.3.jar

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -22,7 +22,7 @@ configurations {
 repositories {
     mavenCentral()
     maven { url = "https://maven.shedaniel.me/" }
-    maven { url = 'https://ladysnake.jfrog.io/artifactory/mods' }
+    maven { url = 'https://maven.ladysnake.org/releases' }
     maven { url = "https://maven.jamieswhiteshirt.com/libs-release/" }
     maven { url = "https://mvn.devos.one/snapshots/" }
     maven { url = "https://maven.terraformersmc.com/releases/" }
@@ -49,7 +49,8 @@ dependencies {
 
     modImplementation "at.petra-k.hexcasting:hexcasting-fabric-1.19.2:0.10.3"
     modImplementation "vazkii.patchouli:Patchouli:1.19.2-77-FABRIC"
-    modImplementation "maven.modrinth:hexal:XMX5kXcI" //Hexal 0.2.14-fabric
+    modImplementation "maven.modrinth:geckolib:ATPZfRS1" // geckolib 3.1.40 fabric
+    modImplementation "maven.modrinth:hexal:NgdFPhMz" //Hexal 0.2.18-fabric
 
     modApi("me.shedaniel.cloth:cloth-config-fabric:8.2.88") {
         exclude(group: "net.fabricmc.fabric-api")

--- a/forge/build.gradle
+++ b/forge/build.gradle
@@ -35,6 +35,10 @@ repositories {
     maven { url = "https://modmaven.dev"}
     maven { url = "https://maven.theillusivec4.top" }
     maven { url = 'https://thedarkcolour.github.io/KotlinForForge/'}
+    maven {
+        name = "Modrinth"
+        url = "https://api.modrinth.com/maven"
+    }
 }
 
 
@@ -46,13 +50,15 @@ dependencies {
     modImplementation("at.petra-k.hexcasting:hexcasting-forge-1.19.2:0.10.3") {
         transitive = false
     }
+    modImplementation("maven.modrinth:hexal:4uxUwDtU")//Hexal 0.2.18-forge
 
     //modRuntimeOnly "top.theillusivec4.curios:curios-forge:1.19.2-5.1.1.0"
-    modRuntimeOnly "mezz.jei:jei-1.19.2-forge:11.4.0.282"
+    modRuntimeOnly "mezz.jei:jei-1.19.2-forge:11.2.0.256"
     modRuntimeOnly "vazkii.patchouli:Patchouli:1.19.2-77"
     modRuntimeOnly "at.petra-k.paucal:paucal-forge-1.19.2:0.5.0"
-    runtimeOnly "thedarkcolour:kotlinforforge:3.7.1"
+    runtimeOnly "thedarkcolour:kotlinforforge:3.12.0"
     //modRuntimeOnly "com.github.Virtuoel:Pehkui:3.6.0-1.19.2-forge"
+    modImplementation "maven.modrinth:geckolib:lxzmD9V4" // geckolib 3.1.40 forge
     modImplementation "vazkii.patchouli:Patchouli:1.19.2-77"
 
     common(project(path: ":common", configuration: "namedElements")) { transitive false }
@@ -72,17 +78,17 @@ shadowJar {
     exclude "architectury.common.json"
 
     configurations = [project.configurations.shadowCommon]
-    classifier "dev-shadow"
+    archiveClassifier.set "dev-shadow"
 }
 
 remapJar {
     input.set shadowJar.archiveFile
     dependsOn shadowJar
-    classifier null
+    archiveClassifier.set null
 }
 
 jar {
-    classifier "dev"
+    archiveClassifier.set "dev"
 }
 
 sourcesJar {

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,6 +12,6 @@ architectury_version=6.2.43
 fabric_loader_version=0.14.9
 fabric_api_version=0.59.0+1.19.2
 
-forge_version=1.19.2-43.0.8
+forge_version=1.19.2-43.2.11
 
 kotlib.stdlib.default.dependency = false


### PR DESCRIPTION
While trying to figure out the cause of mass mindflay crashing, I tried building from source and found there were a lot of outdated dependencies. I updated those, and upon building found that it did not crash. This leads me to believe there have been changes since the public build on modrinth that have already fixed the crash in #9 