### PR TITLE
Make Dict Iota have proper protection from True Name writing

### DIFF
--- a/common/src/main/java/net/walksanator/hextweaks/iotas/DictionaryIota.java
+++ b/common/src/main/java/net/walksanator/hextweaks/iotas/DictionaryIota.java
@@ -149,11 +149,6 @@ public class DictionaryIota extends Iota {
         } else if (cannotBeDictValue.contains(value.getClass())&& !sudo){
             throw new MishapInvalidIota(value,1,Component.translatable("hextweaks.mishap.cannotbevalue"));
         }
-        if (((key instanceof EntityIota) || (value instanceof EntityIota)) && caster != null && !sudo) {
-            Player truename = MishapOthersName.getTrueNameFromArgs(List.of(key,value),caster);
-            if (truename != null)
-                throw new MishapOthersName(truename);
-        }
         Pair<List<Iota>,List<Iota>> data = getPayload();
         int targetKey = -1;
         for (int i = 0; i < data.getFirst().size(); i++)

--- a/common/src/main/java/net/walksanator/hextweaks/mixin/MixinMishapOthersName.java
+++ b/common/src/main/java/net/walksanator/hextweaks/mixin/MixinMishapOthersName.java
@@ -1,0 +1,27 @@
+package net.walksanator.hextweaks.mixin;
+
+import at.petrak.hexcasting.api.spell.SpellList;
+import at.petrak.hexcasting.api.spell.iota.Iota;
+import at.petrak.hexcasting.api.spell.iota.ListIota;
+import at.petrak.hexcasting.api.spell.mishaps.MishapOthersName;
+import net.walksanator.hextweaks.iotas.DictionaryIota;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Mixin(MishapOthersName.Companion.class)
+public class MixinMishapOthersName {
+    @ModifyVariable(method = "getTrueNameFromDatum", at = @At("HEAD"), ordinal = 0)
+    private Iota injected(Iota iota) {
+        if (iota instanceof DictionaryIota dict) {
+            List<Iota> list = new ArrayList<>();
+            list.addAll(dict.getPayload().getFirst());
+            list.addAll(dict.getPayload().getSecond());
+
+            return new ListIota(new SpellList.LList(list));
+        } else return iota;
+    }
+}

--- a/common/src/main/resources/hextweaks-common.mixins.json
+++ b/common/src/main/resources/hextweaks-common.mixins.json
@@ -1,16 +1,17 @@
 {
-	"required": true,
-	"package": "net.walksanator.hextweaks.mixin",
-	"minVersion": "0.8",
-	"compatibilityLevel": "JAVA_17",
-	"client": [
-	],
-	"mixins": [
-		"MixinPatternRegistry",
-		"MixinPerWorldEntry",
-		"MixinRegularEntry"
-	],
-	"injectors": {
-		"defaultRequire": 1
+  "required": true,
+  "package": "net.walksanator.hextweaks.mixin",
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_17",
+  "client": [
+  ],
+  "mixins": [
+    "MixinMishapOthersName",
+    "MixinPatternRegistry",
+    "MixinPerWorldEntry",
+    "MixinRegularEntry"
+  ],
+  "injectors": {
+    "defaultRequire": 1
 	}
 }


### PR DESCRIPTION
Works by adding a mixin to `getTrueNameFromDatum` to transform dictionary iotas into a list iota of both keys and values.

Also removes the true name check when setting a value to a dictionary iota as it is no longer needed.