### PR TITLE
Fix some page flipping and while loop issues

### DIFF
--- a/common/src/main/java/net/walksantor/hextweaks/casting/actions/OpLackingWill.kt
+++ b/common/src/main/java/net/walksantor/hextweaks/casting/actions/OpLackingWill.kt
@@ -15,7 +15,10 @@ object OpLackingWill : ConstMediaAction {
             Component.translatable("hextweaks.action.lackwill")
                 .append(Component.translatable("hextweaks.action.lackwill.will").withStyle(ChatFormatting.ITALIC).withStyle(ChatFormatting.DARK_AQUA)))
 
-        BuiltInRegistries.ENTITY_TYPE.getKey(env.castingEntity.type).toString()
+        val casterType = env.castingEntity?.type;
+        if(casterType != null) {
+            BuiltInRegistries.ENTITY_TYPE.getKey(casterType).toString();
+        }
 
         return listOf()
     }

--- a/common/src/main/java/net/walksantor/hextweaks/casting/actions/OpPageFlip.kt
+++ b/common/src/main/java/net/walksantor/hextweaks/casting/actions/OpPageFlip.kt
@@ -16,17 +16,14 @@ class OpPageFlip(
     override fun execute(args: List<Iota>, env: CastingEnvironment): List<Iota> {
 
         val res = env.getHeldItemToOperateOn {
-                val dataHolder = IXplatAbstractions.INSTANCE.findDataHolder(it) ?: return@getHeldItemToOperateOn false
-            return@getHeldItemToOperateOn dataHolder.readIota(env.world) != null || dataHolder.emptyIota() != null
-            }
+            it.`is`(HexItems.SPELLBOOK.asItem())
+        }
         if (res == null) {return listOf()}
         val handStack = res.component1()
         val hand = res.component2()
 
         if (handStack.`is`(HexItems.SPELLBOOK.asItem())) {
             ItemSpellbook.rotatePageIdx(handStack,rotateRight)
-        } else {
-            throw MishapBadOffhandItem(handStack,hand, Component.literal("Spellbook"))
         }
 
         return listOf()

--- a/common/src/main/java/net/walksantor/hextweaks/casting/environment/ComputerCastingEnv.kt
+++ b/common/src/main/java/net/walksantor/hextweaks/casting/environment/ComputerCastingEnv.kt
@@ -80,7 +80,7 @@ class ComputerCastingEnv(val turtleData: Pair<ITurtleAccess, TurtleSide>?, val p
         }
     }
 
-    override fun extractMediaEnvironment(cost: Long): Long {
+    override fun extractMediaEnvironment(cost: Long, simulate: Boolean): Long {
         @Suppress("NAME_SHADOWING") var cost = cost
         val inventory  = getInventory()
         val adMediaHolders: ArrayList<ADMediaHolder> = ArrayList()
@@ -94,7 +94,7 @@ class ComputerCastingEnv(val turtleData: Pair<ITurtleAccess, TurtleSide>?, val p
         adMediaHolders.sortWith(::compareMediaItem)
         adMediaHolders.reverse()
         for (source in adMediaHolders) {
-            val found = extractMedia(source, cost, drainForBatteries = false, simulate = false)
+            val found = extractMedia(source, cost, drainForBatteries = false, simulate = simulate)
             cost -= found
             if (cost <= 0) {
                 break

--- a/common/src/main/java/net/walksantor/hextweaks/mixin/MixinOpEntityPos.java
+++ b/common/src/main/java/net/walksantor/hextweaks/mixin/MixinOpEntityPos.java
@@ -1,7 +1,7 @@
 package net.walksantor.hextweaks.mixin;
 
 import at.petrak.hexcasting.api.casting.eval.CastingEnvironment;
-import at.petrak.hexcasting.common.casting.actions.OpEntityPos;
+import at.petrak.hexcasting.common.casting.actions.queryentity.OpEntityPos;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import net.minecraft.world.entity.Entity;

--- a/common/src/main/java/net/walksantor/hextweaks/mixin/MixinOperatorSideeffect.java
+++ b/common/src/main/java/net/walksantor/hextweaks/mixin/MixinOperatorSideeffect.java
@@ -9,6 +9,7 @@ import at.petrak.hexcasting.api.casting.mishaps.Mishap;
 import kotlin.collections.CollectionsKt;
 import net.minecraft.nbt.CompoundTag;
 import net.walksantor.hextweaks.casting.environment.MishapAwareCastingEnvironment;
+import org.jetbrains.annotations.NotNull;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -31,8 +32,9 @@ public class MixinOperatorSideeffect {
     @Shadow(remap=false)
     private Mishap.Context errorCtx;
 
+    // [!TODO] Temporarily removed this to prevent crash. I don't know why it does not work.
     @Inject(method = "performEffect(Lat/petrak/hexcasting/api/casting/eval/vm/CastingVM;)Z", at = @At("HEAD"), cancellable = true,remap = false)
-    private void hextweaks$mishapAwareCastingEnv(CastingVM harness, CallbackInfoReturnable<Boolean> cir) {
+    private void hextweaks$mishapAwareCastingEnv(@NotNull CastingVM harness, CallbackInfoReturnable<Boolean> cir) {
         CastingEnvironment env = harness.getEnv();
         if (env instanceof MishapAwareCastingEnvironment mishapAwareEnv) {
             Optional<List<Iota>> res = mishapAwareEnv.onMishap(mishap,errorCtx,harness.getImage().getStack());

--- a/common/src/main/java/net/walksantor/hextweaks/mixin/MixinOperatorSideeffect.java
+++ b/common/src/main/java/net/walksantor/hextweaks/mixin/MixinOperatorSideeffect.java
@@ -15,6 +15,7 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import java.util.Collection;
@@ -32,15 +33,13 @@ public class MixinOperatorSideeffect {
     @Shadow(remap=false)
     private Mishap.Context errorCtx;
 
-    // [!TODO] Temporarily removed this to prevent crash. I don't know why it does not work.
-    @Inject(method = "performEffect(Lat/petrak/hexcasting/api/casting/eval/vm/CastingVM;)Z", at = @At("HEAD"), cancellable = true,remap = false)
-    private void hextweaks$mishapAwareCastingEnv(@NotNull CastingVM harness, CallbackInfoReturnable<Boolean> cir) {
+    @Inject(method = "performEffect", at = @At("HEAD"), cancellable = true,remap = false)
+    private void hextweaks$mishapAwareCastingEnv(CastingVM harness, CallbackInfo ci) {
         CastingEnvironment env = harness.getEnv();
         if (env instanceof MishapAwareCastingEnvironment mishapAwareEnv) {
             Optional<List<Iota>> res = mishapAwareEnv.onMishap(mishap,errorCtx,harness.getImage().getStack());
             if (res.isPresent()) {
-                cir.setReturnValue(true);
-                cir.cancel();
+                ci.cancel();
 
                 CastingImage img = harness.getImage().copy(res.get(),
                         0,

--- a/common/src/main/resources/examplemod-common.mixins.json
+++ b/common/src/main/resources/examplemod-common.mixins.json
@@ -11,7 +11,6 @@
     "MixinClericReporting",
     "MixinClericReportLocation",
     "MixinOpEntityPos",
-    "MixinOperatorSideeffect",
     "NeuralAccessor"
   ],
   "injectors": {

--- a/common/src/main/resources/examplemod-common.mixins.json
+++ b/common/src/main/resources/examplemod-common.mixins.json
@@ -11,6 +11,7 @@
     "MixinClericReporting",
     "MixinClericReportLocation",
     "MixinOpEntityPos",
+    "MixinOperatorSideeffect",
     "NeuralAccessor"
   ],
   "injectors": {

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -72,7 +72,7 @@ dependencies {
         exclude(group: "net.fabricmc.fabric-api")
     }
 
-  //  modImplementation files("${rootProject.rootDir}/libs/hexal-fabric-1.20.1-0.3.0-2.jar")
+    //  modImplementation files("${rootProject.rootDir}/libs/hexal-fabric-1.20.1-0.3.0-2.jar")
     modCompileOnly files("${rootProject.rootDir}/libs/hexal-fabric-1.20.1-0.3.0-2.jar")
 
     modImplementation("software.bernie.geckolib:geckolib-fabric-${minecraft_version}:${geckolib_version}")
@@ -82,7 +82,8 @@ dependencies {
     implementation group: "org.jblas", name: "jblas", version: "1.2.5" //moreiotas crashes without this sometimes
     //modRuntimeOnly "maven.modrinth:8BmcQJ2H:KyRLWNQb"
 
-    modCompileOnly ("com.github.dafuqs:spectrum:1.20.1-main-SNAPSHOT")
+    //modCompileOnly ("com.github.dafuqs:spectrum:1.20.1-main-SNAPSHOT")
+    modCompileOnly ("curse.maven:spectrum-556967:5628619")
     modCompileOnly ("maven.modrinth:revelationary:${project.revelationary_version}")
     modCompileOnly "com.sk89q.worldedit:worldedit-fabric-mc1.20:7.3.0-SNAPSHOT"
     modRuntimeOnly "curse.maven:worldedit-225608:4586218"

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,7 +20,7 @@ fabric_api_version=0.90.4+1.20.1
 forge_version=1.20.1-47.2.1
 
 #dep versions
-hexcasting_version=0.11.1-7-pre-619
+hexcasting_version=0.11.1-7-pre-676
 cct_version=1.109.3
 patchouli_version=1.20.1-84
 paucal_version=0.6.0-pre-118

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,7 +20,7 @@ fabric_api_version=0.90.4+1.20.1
 forge_version=1.20.1-47.2.1
 
 #dep versions
-hexcasting_version=0.11.1-7-pre-676
+hexcasting_version=0.11.2-pre-702
 cct_version=1.109.3
 patchouli_version=1.20.1-84
 paucal_version=0.6.0-pre-118


### PR DESCRIPTION
- Fix page flipping not working on empty pages.
- Fix page flipping crashing the game on non-spellbook iota-containing items.
- Fix empty while loops freezing the game.

Should fix #22 #21 #14.

Notes:

- The page flipping spells now explicitly ask for a spellbook item, either with or without an iota. An invalid item on the offhand will NOT cause any mishap. I chose to modify it this way because I see that some people who try to draw Mind's Reflection very quickly may slip and mistakenly draw it as one of those page flipping patterns. Having the casting item thrown out due to this minor mistake can be annoying.
- Trying to start a while loop with a truthy value and an empty pattern list will now instantly cause the "Recursively evaluated too deeply" mishap without wasting any time, since doing so would always cause an unrecoverable infinite loop before.
